### PR TITLE
Make basestring and unicode typechecking compatible with python3

### DIFF
--- a/biryani/baseconv.py
+++ b/biryani/baseconv.py
@@ -1741,13 +1741,14 @@ def structured_mapping(converters, constructor = None, default = None, drop_none
     ...     )(collections.OrderedDict(name = u'John Doe', age = u'72', email = u'john@doe.name'))
     ({'age': 72, 'email': u'john@doe.name', 'name': u'John Doe'}, None)
     """
+
     if constructor is None:
         constructor = type(converters)
     converters = constructor(
         (name, converter)
-        for name, converter in (converters or {}).iteritems()
+        for name, converter in (converters or {}).items()
         if converter is not None
-        )
+    )
 
     def structured_mapping_converter(values, state = None):
         if values is None:
@@ -1775,7 +1776,7 @@ def structured_mapping(converters, constructor = None, default = None, drop_none
                     values_converter[name] = default if default is not None else fail(error = N_(u'Unexpected item'))
         errors = constructor()
         converted_values = constructor()
-        for name, converter in values_converter.iteritems():
+        for name, converter in values_converter.items():
             if skip_missing_items and name not in values:
                 continue
             value, error = converter(values.get(name), state = state)

--- a/biryani/baseconv.py
+++ b/biryani/baseconv.py
@@ -313,7 +313,7 @@ def fail(error = N_(u'An error occured')):
     def fail_converter(value, state = None):
         if state is None:
             state = states.default_state
-        return value, state._(error) if isinstance(error, basestring) else error
+        return value, state._(error) if strings.is_basestring(error) else error
     return fail_converter
 
 
@@ -426,7 +426,7 @@ def get(key, default = UnboundLocalError, error = None):
             if converted_value is UnboundLocalError:
                 return None, state._(u'Unknown key: {0}').format(key) \
                     if error is None \
-                    else state._(error) if isinstance(error, basestring) else error
+                    else state._(error) if strings.is_basestring(error) else error
             return converted_value, None
         assert isinstance(value, collections.Sequence), \
             'Value must be a mapping or a sequence. Got {0} instead.'.format(type(value))
@@ -435,7 +435,7 @@ def get(key, default = UnboundLocalError, error = None):
         if default is UnboundLocalError:
             return None, state._(u'Index out of range: {0}').format(key) \
                 if error is None \
-                else state._(error) if isinstance(error, basestring) else error
+                else state._(error) if strings.is_basestring(error) else error
         return default, None
     return get_converter
 
@@ -590,7 +590,7 @@ def make_anything_to_float(accept_expression = False):
             return value, None
         if state is None:
             state = states.default_state
-        if accept_expression and isinstance(value, basestring):
+        if accept_expression and strings.is_basestring(value):
             value = value.strip()
             if numerical_expression_re.match(value) is None:
                 return value, state._(u"Value must be a valid floating point expression")
@@ -641,7 +641,7 @@ def make_anything_to_int(accept_expression = False):
             return value, None
         if state is None:
             state = states.default_state
-        if accept_expression and isinstance(value, basestring):
+        if accept_expression and strings.is_basestring(value):
             value = value.strip()
             if numerical_expression_re.match(value) is None:
                 return value, state._(u"Value must be a valid integer expression")
@@ -2037,7 +2037,7 @@ def test(function, error = N_(u'Test failed'), handle_none_value = False, handle
         ok = function(value, state = state) if handle_state else function(value)
         if ok:
             return value, None
-        return value, state._(error) if isinstance(error, basestring) else error
+        return value, state._(error) if strings.is_basestring(error) else error
     return test_converter
 
 
@@ -2253,7 +2253,7 @@ def test_none(error = N_(u'Unexpected value')):
             return value, None
         if state is None:
             state = states.default_state
-        return value, state._(error) if isinstance(error, basestring) else error
+        return value, state._(error) if strings.is_basestring(error) else error
     return none
 
 

--- a/biryani/baseconv.py
+++ b/biryani/baseconv.py
@@ -35,7 +35,7 @@
 import __future__
 import re
 
-from . import states, strings
+from biryani import states, strings
 
 
 __all__ = [

--- a/biryani/strings.py
+++ b/biryani/strings.py
@@ -122,7 +122,7 @@ def deep_decode(value, encoding = 'utf-8'):
     >>> print deep_decode(None)
     None
     """
-    return value if isinstance(value, unicode) else value.decode(encoding) if isinstance(value, str) \
+    return value if is_unicode(value) else value.decode(encoding) if isinstance(value, str) \
         else dict(
             (deep_decode(name, encoding = encoding), deep_decode(item, encoding = encoding))
             for name, item in value.iteritems()
@@ -152,7 +152,7 @@ def deep_encode(value, encoding = 'utf-8'):
     >>> print deep_encode(None)
     None
     """
-    return value if isinstance(value, str) else value.encode(encoding) if isinstance(value, unicode) \
+    return value if isinstance(value, str) else value.encode(encoding) if is_unicode(value) \
         else dict(
             (deep_encode(name, encoding = encoding), deep_encode(item, encoding = encoding))
             for name, item in value.iteritems()
@@ -204,9 +204,9 @@ def normalize(s, encoding = 'utf-8', separator = u' ', transform = lower):
     """
     if s is None:
         return None
-    if isinstance(s, str):
+    if not is_unicode(s):
         s = s.decode(encoding)
-    assert isinstance(s, unicode), str((s,))
+    assert is_unicode(s), str((s,))
     normalized = u''.join(c for c in unicodedata.normalize('NFKD', s) if unicodedata.combining(c) == 0)
     normalized = separator.join(normalized.strip().split())
     if transform is not None:
@@ -230,9 +230,9 @@ def slugify(s, encoding = 'utf-8', separator = u'-', transform = lower):
     """
     if s is None:
         return None
-    if isinstance(s, str):
+    if not is_unicode(s):
         s = s.decode(encoding)
-    assert isinstance(s, unicode), str((s,))
+    assert is_unicode(s), str((s,))
     simplified = u''.join([slugify_char(unicode_char) for unicode_char in s])
     while u'  ' in simplified:
         simplified = simplified.replace(u'  ', u' ')
@@ -288,3 +288,25 @@ def upper(s):
     if s is None:
         return None
     return s.upper()
+
+def is_basestring(text):
+    """Check that an element is a str in python 3 or a basestring in python 2.
+        >>> is_basestring('Hello world!')
+        True
+        >>> is_basestring(u'Hello world!')
+        True
+        >>> is_basestring(42)
+        False
+        """
+    return isinstance(text, "".__class__) or isinstance(text, u"".__class__)
+
+def is_unicode(text):
+    """Check that an element is a str in python 3 or a basestring in python 2.
+        >>> is_basestring('Hello world!')
+        True
+        >>> is_basestring(u'Hello world!')
+        True
+        >>> is_basestring(42)
+        False
+        """
+    return isinstance(text, u"".__class__)

--- a/biryani/strings.py
+++ b/biryani/strings.py
@@ -111,15 +111,15 @@ ASCII_TRANSLATIONS = {
 def deep_decode(value, encoding = 'utf-8'):
     """Convert recursively bytes strings embedded in Python data to unicode strings.
 
-    >>> deep_decode('Hello world!')
-    u'Hello world!'
-    >>> deep_decode(dict(a = 'b', c = ['d', 'e']))
-    {u'a': u'b', u'c': [u'd', u'e']}
-    >>> deep_decode(u'Hello world!')
-    u'Hello world!'
+    >>> print(deep_decode('Hello world!'))
+    Hello world!
+    >>> is_unicode(deep_decode('Hello world!'))
+    True
+    >>> is_unicode(deep_decode(u'Hello world!'))
+    True
     >>> deep_decode(42)
     42
-    >>> print deep_decode(None)
+    >>> print(deep_decode(None))
     None
     """
     return value if is_unicode(value) else value.decode(encoding) if isinstance(value, str) \
@@ -143,13 +143,13 @@ def deep_encode(value, encoding = 'utf-8'):
 
     >>> deep_encode(u'Hello world!')
     'Hello world!'
-    >>> deep_encode({u'a': u'b', u'c': [u'd', u'e']})
-    {'a': 'b', 'c': ['d', 'e']}
+    >>> is_unicode(deep_decode(dict(a = 'b', c = ['d', 'e']))['a'])
+    True
     >>> deep_encode('Hello world!')
     'Hello world!'
     >>> deep_encode(42)
     42
-    >>> print deep_encode(None)
+    >>> print(deep_encode(None))
     None
     """
     return value if isinstance(value, str) else value.encode(encoding) if is_unicode(value) \
@@ -176,9 +176,11 @@ def lower(s):
 
     >>> lower('Hello world!')
     'hello world!'
-    >>> lower(u'Hello world!')
-    u'hello world!'
-    >>> print lower(None)
+    >>> lower('Hello world!').__class__.__name__
+    'str'
+    >>> is_unicode(lower(u'Hello world!'))
+    True
+    >>> print(lower(None))
     None
     """
     if s is None:
@@ -189,17 +191,15 @@ def lower(s):
 def normalize(s, encoding = 'utf-8', separator = u' ', transform = lower):
     """Convert a string to its normal form using compatibility decomposition and removing combining characters.
 
-    >>> normalize(u'Hello world!')
-    u'hello world!'
-    >>> normalize(u'   Hello   world!   ')
-    u'hello world!'
-    >>> normalize('œil, forêt, ça, où...')
-    u'\u0153il, foret, ca, ou...'
-    >>> normalize('Hello world!')
-    u'hello world!'
-    >>> normalize(u'   ')
-    u''
-    >>> print normalize(None)
+    >>> print(normalize('Hello world!'))
+    hello world!
+    >>> print(normalize('   Hello   world!   '))
+    hello world!
+    >>> print(normalize('forêt, ça, où...'))
+    foret, ca, ou...
+    >>> is_unicode(normalize('Hello world!'))
+    True
+    >>> print(normalize(None))
     None
     """
     if s is None:
@@ -217,15 +217,17 @@ def normalize(s, encoding = 'utf-8', separator = u' ', transform = lower):
 def slugify(s, encoding = 'utf-8', separator = u'-', transform = lower):
     """Simplify a string, converting it to a lowercase ASCII subset.
 
-    >>> slugify(u'Hello world!')
-    u'hello-world'
-    >>> slugify(u'   Hello   world!   ')
-    u'hello-world'
-    >>> slugify('œil, forêt, ça, où...')
-    u'oeil-foret-ca-ou'
-    >>> slugify('Hello world!')
-    u'hello-world'
-    >>> print slugify(None)
+    >>> print(slugify('Hello world!'))
+    hello-world
+    >>> print(slugify('   Hello   world!   '))
+    hello-world
+    >>> print(slugify('œil, forêt, ça, où...'))
+    oeil-foret-ca-ou
+    >>> is_unicode(slugify('œil, forêt, ça, où...'))
+    True
+    >>> is_unicode(slugify(str('Hello world!')))
+    True
+    >>> print(slugify(None))
     None
     """
     if s is None:
@@ -278,11 +280,13 @@ def upper(s):
     .. note:: This method is equivalent to the ``upper()`` method of strings, but can be used when a function is
        expected, for example by the :func:`normalize` & :func:`slugify` functions.
 
-    >>> upper('Hello world!')
-    'HELLO WORLD!'
-    >>> upper(u'Hello world!')
-    u'HELLO WORLD!'
-    >>> print upper(None)
+    >>> print(upper('Hello world!'))
+    HELLO WORLD!
+    >>> upper('Hello world!').__class__.__name__
+    'str'
+    >>> is_unicode(upper(u'Hello world!'))
+    True
+    >>> print(upper(None))
     None
     """
     if s is None:
@@ -310,3 +314,8 @@ def is_unicode(text):
         False
         """
     return isinstance(text, u"".__class__)
+
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()

--- a/biryani/strings.py
+++ b/biryani/strings.py
@@ -125,7 +125,7 @@ def deep_decode(value, encoding = 'utf-8'):
     return value if is_unicode(value) else value.decode(encoding) if isinstance(value, str) \
         else dict(
             (deep_decode(name, encoding = encoding), deep_decode(item, encoding = encoding))
-            for name, item in value.iteritems()
+            for name, item in value.items()
             ) if isinstance(value, dict) \
         else [
             deep_decode(item, encoding = encoding)
@@ -155,7 +155,7 @@ def deep_encode(value, encoding = 'utf-8'):
     return value if isinstance(value, str) else value.encode(encoding) if is_unicode(value) \
         else dict(
             (deep_encode(name, encoding = encoding), deep_encode(item, encoding = encoding))
-            for name, item in value.iteritems()
+            for name, item in value.items()
             ) if isinstance(value, dict) \
         else [
             deep_encode(item, encoding = encoding)

--- a/biryani/strings.py
+++ b/biryani/strings.py
@@ -122,7 +122,7 @@ def deep_decode(value, encoding = 'utf-8'):
     >>> print(deep_decode(None))
     None
     """
-    return value if is_unicode(value) else value.decode(encoding) if isinstance(value, str) \
+    return value if is_unicode(value) else value.decode(encoding) if isinstance(value, "".__class__) \
         else dict(
             (deep_decode(name, encoding = encoding), deep_decode(item, encoding = encoding))
             for name, item in value.items()
@@ -152,7 +152,7 @@ def deep_encode(value, encoding = 'utf-8'):
     >>> print(deep_encode(None))
     None
     """
-    return value if isinstance(value, str) else value.encode(encoding) if is_unicode(value) \
+    return value if isinstance(value, "".__class__) else value.encode(encoding) if is_unicode(value) \
         else dict(
             (deep_encode(name, encoding = encoding), deep_encode(item, encoding = encoding))
             for name, item in value.items()
@@ -302,7 +302,7 @@ def is_basestring(text):
         >>> is_basestring(42)
         False
         """
-    return isinstance(text, "".__class__) or isinstance(text, u"".__class__)
+    return isinstance(text, ("".__class__, u"".__class__))
 
 def is_unicode(text):
     """Check that an element is a str in python 3 or a basestring in python 2.

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ doc_lines = __doc__.split('\n')
 
 setup(
     name='Biryani',
-    version='0.10.5dev',
+    version='0.10.6dev',
 
     author='Emmanuel Raviart',
     author_email='emmanuel@raviart.com',


### PR DESCRIPTION
This PR changes the `unicode` and `basetring` typecheck so they are compatible between python2 and python3